### PR TITLE
Country field uses the alpha-2 code

### DIFF
--- a/source/includes/customers/_clients.md
+++ b/source/includes/customers/_clients.md
@@ -123,7 +123,7 @@ street_address | The street address <small>string</small>
 city | The city <small>string</small>
 state | The state <small>string</small>
 zipcode | The ZIP code <small>string</small>
-country | The country <small>string</small>
+country | The country (alpha-2 code) <small>string</small>
 website | A website for the client <small>string</small>
 phone | A phone number for the client <small>string</small>
 description | A description for the client <small>string</small>
@@ -163,7 +163,7 @@ street_address | The street address <small>string</small>
 city | The city <small>string</small>
 state | The state <small>string</small>
 zipcode | The ZIP code <small>string</small>
-country | The country <small>string</small>
+country | The country (alpha-2 code) <small>string</small>
 website | A website for the client <small>string</small>
 phone | A phone number for the client <small>string</small>
 description | A description for the client <small>string</small>

--- a/source/includes/customers/_projects.md
+++ b/source/includes/customers/_projects.md
@@ -259,7 +259,7 @@ city | The city of the project <small>string</small>
 state | The state of the project <small>string</small>
 street_address | The street_address of the project <small>string</small>
 zipcode | The zipcode of the project <small>string</small>
-country | The country of the project <small>string</small>
+country | The country of the project (alpha-2 code) <small>string</small>
 price_valid_until | The date the price is valid until (e.g. 2021-02-14) <small>string</small>
 tax | The sales tax of the project <small>decimal</small>
 contract_number | The contract number of the project <small>string</small>
@@ -316,7 +316,7 @@ city | The city of the project <small>string</small>
 state | The state of the project <small>string</small>
 street_address | The street_address of the project <small>string</small>
 zipcode | The zipcode of the project <small>string</small>
-country | The country of the project <small>string</small>
+country | The country of the project (alpha-2 code) <small>string</small>
 price_valid_until | The date the price is valid until (e.g. 2021-02-14) <small>string</small>
 tax | The sales tax of the project <small>decimal</small>
 contract_number | The contract number of the project <small>string</small>


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->