### PR TITLE
Add note regarding product currency

### DIFF
--- a/source/includes/vendors/_products.md
+++ b/source/includes/vendors/_products.md
@@ -176,6 +176,8 @@ ID | The ID of the product to update
 
 Same as [Create a product](#create-a-product).
 
+Note: `currency` cannot be changed after product creation.
+
 
 ## Discontinue a product
 


### PR DESCRIPTION
Product currency cannot be changed after the product has been created.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->