### PR TITLE
Vendors API: Include discontinued products in products search

### DIFF
--- a/source/includes/vendors/_products.md
+++ b/source/includes/vendors/_products.md
@@ -36,7 +36,7 @@
 
 > Status: 200 OK
 
-This endpoint allows querying all products by model.
+This endpoint allows querying all products (active and discontinued) by model.
 
 ### HTTP Request
 
@@ -58,7 +58,7 @@ page | A specific page of results.
 
 > Status: 200 OK
 
-This endpoint retrieves all of your products.
+This endpoint retrieves all of your products (active and discontinued).
 
 ### HTTP Request
 


### PR DESCRIPTION
Adds a note stating that all products returned by the endpoint also includes discontinued products.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->