### PR TITLE
Add item cost field to API

### DIFF
--- a/source/includes/customers/projects/_items.md
+++ b/source/includes/customers/projects/_items.md
@@ -262,3 +262,4 @@ phase_id | The phase of the item <small>integer</small>
 short_description | Description of the item <small>string</small>
 external_notes | Customer visible notes for the item <small>string</small>
 quantity_per_room | The quantity for the item <small>decimal</small>
+cost | The item cost <small>decimal</small>


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->