### PR TITLE
CustomersAPI: Add timestamp query params to projects endpoint

### DIFF
--- a/source/includes/customers/_projects.md
+++ b/source/includes/customers/_projects.md
@@ -99,7 +99,14 @@ It includes any shared projects, and only lists the active version (if multiple 
 Parameter | Description
 --------- | -----------
 page | A specific page of results.
+min_created_at | Query projects created after the specified date time.
+max_created_at | Query projects created before the specified date time.
+min_updated_at | Query projects updated after the specified date time.
+max_updated_at | Query projects updated before the specified date time.
 
+**Note**: You can pass a date or a date time to the timestamp queries. For example:
+`2023-7-28` or `2023-7-28 15:33:33 -700` or `2023-7-28T15:33:33-700`. The time defaults to
+`00:00:00` when not included, and the timezone defaults to UTC.
 
 ## Get a project
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->