### PR TITLE
Vendors API: Add required currency_code to pricing tiers

### DIFF
--- a/source/includes/vendors/_pricing_tiers.md
+++ b/source/includes/vendors/_pricing_tiers.md
@@ -11,12 +11,14 @@
   {
     "id": 3495,
     "name": "Default",
+    "currency_code": "USD",
     "created_at": "2016-08-17T17:14:45.430-07:00",
     "updated_at": "2016-08-17T17:14:45.430-07:00"
   },
   {
     "id": 3496,
     "name": "Tier 2",
+    "currency_code": "USD",
     "created_at": "2016-08-17T17:14:45.430-07:00",
     "updated_at": "2016-08-17T17:14:45.430-07:00"
   }
@@ -42,7 +44,8 @@ page | A specific page of results.
 <%
   data =
     {
-      "name": "Gold"
+      "name": "Gold",
+      "currency_code": "USD"
     }
 %>
 <%= shell_example('/pricing_tiers', command: 'POST', data: data) %>
@@ -53,6 +56,7 @@ page | A specific page of results.
 {
   "id":17487,
   "name":"Gold",
+  "currency_code": "USD",
   "created_at":"2018-10-02T18:36:59.949-07:00",
   "updated_at":"2018-10-02T18:36:59.949-07:00",
 }
@@ -71,3 +75,4 @@ This endpoint creates a new pricing tier.
 Parameter | Description
 --------- | -----------
 name | The name of the tier (required)
+currency_code | A 3 letter ISO code (e.g. USD, EUR, JPY) (required)


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->