### PR TITLE
Customers Products API: Remove deleted_at field

### DIFF
--- a/source/includes/customers/_products.md
+++ b/source/includes/customers/_products.md
@@ -24,7 +24,6 @@
       "shipping_cost": "0.0",
       "shipping_price": "55.0",
       "discontinued": false,
-      "deleted_at": null,
       "notes": "",
       "warranty_value": "24.0",
       "warranty_unit": "mo",


### PR DESCRIPTION
This field should not be in use.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->