### PR TITLE
Add purchasing source info to items endpoint

### DIFF
--- a/source/includes/customers/projects/_items.md
+++ b/source/includes/customers/projects/_items.md
@@ -48,6 +48,10 @@
       "custom": false,
       "product_id": 1251085,
       "custom_product_id": null,
+      "purchasing_source": {
+        "id": 441,
+        "company_name": "Shure"
+      },
       "quantity": "20.0",
       "quantity_per_room": "10.0",
       "quantity_per_bundle": null,


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->