### PR TITLE
Customer's API: Add labor programs

### DIFF
--- a/source/customers/index.html.md
+++ b/source/customers/index.html.md
@@ -12,6 +12,7 @@ includes:
   - customers/clients
   - customers/clients/contacts
   - customers/labor_presets
+  - customers/labor_programs
   - customers/market_segments
   - customers/phases
   - customers/products

--- a/source/includes/customers/_labor_programs.md
+++ b/source/includes/customers/_labor_programs.md
@@ -1,0 +1,41 @@
+# Labor Programs
+
+## Get all labor programs
+
+<%= shell_example('/labor_programs') %>
+
+> Response:
+
+```json
+[
+  {
+    "id": 101,
+    "name": "NYC Labor Package",
+    "office_id": null,
+    "created_at": "2019-09-25T11:38:16.835-07:00",
+    "updated_at": "2024-12-02T00:48:12.397-08:00"
+  },
+  ...
+]
+```
+
+> Status: 200 OK
+
+This endpoint retrieves all your labor programs.
+
+### HTTP Request
+
+`GET <%= api_url('/labor_programs') %>`
+
+`GET <%= api_url('/labor_programs?page=2') %>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+office_id | Labor programs belonging to the specified office
+page | A specific page of results.
+min_created_at | Query results created after the specified date time.
+max_created_at | Query results created before the specified date time.
+min_updated_at | Query results updated after the specified date time.
+max_updated_at | Query results updated before the specified date time.

--- a/source/includes/customers/_projects.md
+++ b/source/includes/customers/_projects.md
@@ -74,6 +74,9 @@
     "market_segment": {
       "id": 98
     },
+    "labor_program": {
+      "id": null
+    },
     "currency": "USD",
     "exchange_rates": { "CAD": 1.243825 },
     "image_url": "projects/project-avatar-3.jpg",
@@ -193,6 +196,12 @@ query | Filter by project name, custom_id, city, clients company name, clients f
   "company_location": {
     "id": 3,
     "name": "Jetbuilt Testing"
+  },
+  "market_segment": {
+    "id": 98
+  },
+  "labor_program": {
+    "id": null
   },
   "currency": "USD",
   "exchange_rates": { "CAD": 1.243825 },
@@ -332,6 +341,9 @@ This endpoint creates a new project.
 
 Defaults to the `opportunity` stage.
 
+### Labor Programs
+The default labor program will be assigned unless the `labor_program_id` key is in the request. Ex: You can pass a `null` value or a valid Labor Program ID to override your company's default labor program settings.
+
 ### HTTP Request
 
 `POST <%= api_url('/projects') %>`
@@ -372,6 +384,7 @@ engineer_id | The user who is the engineer <small>integer</small>
 second_engineer_id | The user who is the engineer <small>integer</small>
 avso | Indicates if the project is an AVSO project <small>boolean</small>
 avso_region | The Projects AVSO Region <small>string</small> <br />All possible values: **Atlantic, National Capital, Ontario, Pacific, Québec, Western** <small>Sending an invalid value will unset the field</small>
+labor_program_id | The project's labor program <small>integer</small>
 
 ## Update a project
 <%
@@ -442,6 +455,7 @@ engineer_id | The user who is the engineer <small>integer</small>
 second_engineer_id | The user who is the engineer <small>integer</small>
 avso | Indicates if the project is an AVSO project <small>boolean</small>
 avso_region | The Projects AVSO Region <small>string</small> <br />All possible values: **Atlantic, National Capital, Ontario, Pacific, Québec, Western** <small>Sending an invalid value will unset the field</small>
+labor_program_id | The project's labor program <small>integer</small>
 
 ## Create a project revision
 <%


### PR DESCRIPTION
Created a labor programs endpoint listing all labor programs. The labor program field is retrievable from the project's endpoint. Projects can be created/updated with the specified labor program. By default, Projects are still created with the company's default labor program as long as the `labor_program_id` is absent from the request.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->