### PR TITLE
Update the `shipping_total` value for Get a Project and Get all Projects

### DIFF
--- a/source/includes/customers/_projects.md
+++ b/source/includes/customers/_projects.md
@@ -39,7 +39,10 @@
     "sales_tax": "0.1",
     "equipment_total": "22257.98",
     "labor_total": "33000.0",
-    "shipping_total": "0.0",
+    "shipping_total": {
+      "cents": 287900,
+      "currency_iso": "USD"
+    },
     "tax_total": "3366.5",
     "total": "58624.48",
     "address": "",
@@ -170,7 +173,10 @@ query | Filter by project name, custom_id, city, clients company name, clients f
   "equipment_margin": "27.5",
   "equipment_total": "22257.98",
   "labor_total": "33000.0",
-  "shipping_total": "0.0",
+  "shipping_total": {
+      "cents": 287900,
+      "currency_iso": "USD"
+    },
   "tax_total": "3366.5",
   "total": "58624.48",
   "address": "",


### PR DESCRIPTION
Hello @jaredmoody !

[User 56402](https://app.jetbuilt.com/backend/users/56402/edit) brought this up in chat, so I figure I'd just update the docs here. 

At some point the currency and cents values got added to the `shipping_total` value for the Get All Projects, and Get a Project endpoints. Postman pic below just to confirm.

![image](https://github.com/user-attachments/assets/4c5b6a9b-bc2e-45c2-af18-6b546f148d1f)


Thanks!