### PR TITLE
Update timestamp query documentation

### DIFF
--- a/source/customers/index.html.md
+++ b/source/customers/index.html.md
@@ -7,6 +7,7 @@ language_tabs: # must be one of https://git.io/vQNgJ
 
 includes:
   - intro
+  - customers/intro
   - customers/auth
   - customers/company
   - customers/clients

--- a/source/includes/customers/_intro.md
+++ b/source/includes/customers/_intro.md
@@ -1,0 +1,13 @@
+## Querying by timestamp
+
+Endpoints that retrieve multiple records support querying data by timestamps, unless otherwise specified.
+
+Parameter | Description
+--------- | -----------
+min_created_at | Query records created after the specified date time.
+max_created_at | Query records created before the specified date time.
+min_updated_at | Query records updated after the specified date time.
+max_updated_at | Query records updated before the specified date time.
+
+**Note**: You can pass a date or a date time to the timestamp queries. For example:
+`2023-7-28` or `2023-7-28 15:33:33 -700` or `2023-7-28T15:33:33-700`. The time defaults to `00:00:00` when not included, and the timezone defaults to UTC.

--- a/source/includes/customers/_labor_programs.md
+++ b/source/includes/customers/_labor_programs.md
@@ -35,7 +35,3 @@ Parameter | Description
 --------- | -----------
 office_id | Labor programs belonging to the specified office
 page | A specific page of results.
-min_created_at | Query results created after the specified date time.
-max_created_at | Query results created before the specified date time.
-min_updated_at | Query results updated after the specified date time.
-max_updated_at | Query results updated before the specified date time.

--- a/source/includes/customers/_products.md
+++ b/source/includes/customers/_products.md
@@ -104,10 +104,6 @@ model | Filter results by model name <small> must be an exact match</small>
 currency_code | Filter results by currency code. _e.g CAD_. <small>defaults to USD</small>
 query | Filter results by matching across manufacturer and model names <small>does not need to match exactly</small> <br/> _e.g. Shure SM57_
 page | A specific page of results.
-min_created_at | Query products created after the specified date time.
-max_created_at | Query products created before the specified date time.
-min_updated_at | Query products updated after the specified date time.
-max_updated_at | Query products updated before the specified date time.
 
 If filtering with the `query` param, then it takes precedence, and the other filtering params are ignored. Can be used when unsure about the exact manufacturer or model name.
 

--- a/source/includes/customers/_projects.md
+++ b/source/includes/customers/_projects.md
@@ -118,17 +118,9 @@ It includes any shared projects, and only lists the active version (if multiple 
 Parameter | Description
 --------- | -----------
 page | A specific page of results.
-min_created_at | Query projects created after the specified date time.
-max_created_at | Query projects created before the specified date time.
-min_updated_at | Query projects updated after the specified date time.
-max_updated_at | Query projects updated before the specified date time.
 active | (true/false) returns projects in an active stage when true; otherwise returns projects in non-active stages
 stage | Filter projects by stage (a single stage name or a comma separated list - param is ignored when active param is present)
 query | Filter by project name, custom_id, city, clients company name, clients first or last name
-
-**Note**: You can pass a date or a date time to the timestamp queries. For example:
-`2023-7-28` or `2023-7-28 15:33:33 -700` or `2023-7-28T15:33:33-700`. The time defaults to
-`00:00:00` when not included, and the timezone defaults to UTC.
 
 ## Get a project
 

--- a/source/includes/customers/_purchase_orders.md
+++ b/source/includes/customers/_purchase_orders.md
@@ -48,10 +48,6 @@ Parameter | Description
 --------- | -----------
 page | A specific page of results.
 project_id | an optional project id to filter by
-min_created_at | Query purchase orders created after the specified date time.
-max_created_at | Query purchase orders created before the specified date time.
-min_updated_at | Query purchase orders updated after the specified date time.
-max_updated_at | Query purchase orders updated before the specified date time.
 
 ## Get a purchase order
 

--- a/source/includes/customers/_service_cases.md
+++ b/source/includes/customers/_service_cases.md
@@ -44,14 +44,6 @@ This endpoint retrieves all of your service cases.
 Parameter | Description
 --------- | -----------
 page | A specific page of results.
-min_created_at | Query service cases created after the specified date time.
-max_created_at | Query service cases created before the specified date time.
-min_updated_at | Query service cases updated after the specified date time.
-max_updated_at | Query service cases updated before the specified date time.
-
-**Note**: You can pass a date or a date time to the timestamp queries. For example:
-`2023-7-28` or `2023-7-28 15:33:33 -700` or `2023-7-28T15:33:33-700`. The time defaults to
-`00:00:00` when not included, and the timezone defaults to UTC.
 
 ## Get a service case
 

--- a/source/includes/customers/projects/_discussions.md
+++ b/source/includes/customers/projects/_discussions.md
@@ -45,3 +45,5 @@ Parameter | Description
 --------- | -----------
 PROJECT_ID | The ID of the project
 page | A specific page of results.
+
+**Note**: Timestamp-based queries are not supported by this endpoint.

--- a/source/includes/customers/projects/_proposals.md
+++ b/source/includes/customers/projects/_proposals.md
@@ -50,9 +50,5 @@ Parameter | Description
 PROJECT_ID | The ID of the project
 page | A specific page of results
 expiry_public_link | if set to `true` a public link is generated that expires after 5 minutes
-min_created_at | Get proposals created after the specified date time.
-max_created_at | Get proposals created before the specified date time.
-min_updated_at | Get proposals updated after the specified date time.
-max_updated_at | Get proposals updated before the specified date time.
 min_view_date | Get proposals that had views after the specified date time.
 max_view_date | Get proposals that had views before the specified date time.

--- a/source/includes/customers/projects/_purchasing.md
+++ b/source/includes/customers/projects/_purchasing.md
@@ -59,3 +59,5 @@ Parameter | Description
 --------- | -----------
 PROJECT_ID | The ID of the project
 page | A specific page of line item results
+
+**Note**: Timestamp-based queries are not supported by this endpoint.


### PR DESCRIPTION
Timestamp based querying has been added to almost all of the customer API endpoints.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->